### PR TITLE
Bugfix for codegen_test + regenerated goldens

### DIFF
--- a/pasta/base/codegen_test.py
+++ b/pasta/base/codegen_test.py
@@ -81,15 +81,11 @@ class AutoFormatTest(with_metaclass(AutoFormatTestMeta, test_utils.TestCase)):
     t = ast.parse(src)
     self.assertEqual('exec(foo, bar)\n', pasta.dump(t))
 
+  @test_utils.requires_features('bytes_node')
   def test_bytes(self):
     src = "b'foo'"
     t = ast.parse(src)
     self.assertEqual("b'foo'\n", pasta.dump(t))
-
-  def test_re_str(self):
-    src = "r'foo'"
-    t = ast.parse(src)
-    self.assertEqual("r'foo'\n", pasta.dump(t))
 
 
 def suite():

--- a/pasta/base/test_utils.py
+++ b/pasta/base/test_utils.py
@@ -66,6 +66,8 @@ def requires_features(*features):
 
 
 def supports_feature(feature):
+  if feature == 'bytes_node':
+    return hasattr(ast, 'Bytes') and issubclass(ast.Bytes, ast.AST)
   if feature == 'exec_node':
     return hasattr(ast, 'Exec') and issubclass(ast.Exec, ast.AST)
   if feature == 'type_annotations':

--- a/testdata/ast/golden/2.7/bytes.out
+++ b/testdata/ast/golden/2.7/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Str                  	prefix=||	suffix=||	indent=||
+(3, 0)       Str                  	prefix=||	suffix=||	indent=||
+(5, 0)       Str                  	prefix=||	suffix=||	indent=||
+(7, 0)       Str                  	prefix=||	suffix=||	indent=||
+(13, -1)     Str                  	prefix=||	suffix=||	indent=||
+(15, 1)      Str                  	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Str                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/compare.out
+++ b/testdata/ast/golden/2.7/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Str                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/bytes.out
+++ b/testdata/ast/golden/3.4/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(3, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(5, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(7, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(13, -1)     Bytes                	prefix=||	suffix=||	indent=||
+(15, 1)      Bytes                	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Bytes                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/compare.out
+++ b/testdata/ast/golden/3.4/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Bytes                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.5/bytes.out
+++ b/testdata/ast/golden/3.5/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(3, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(5, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(7, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(13, -1)     Bytes                	prefix=||	suffix=||	indent=||
+(15, 1)      Bytes                	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Bytes                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.5/compare.out
+++ b/testdata/ast/golden/3.5/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Bytes                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.6/bytes.out
+++ b/testdata/ast/golden/3.6/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(3, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(5, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(7, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(13, -1)     Bytes                	prefix=||	suffix=||	indent=||
+(15, 1)      Bytes                	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Bytes                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.6/compare.out
+++ b/testdata/ast/golden/3.6/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Bytes                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||


### PR DESCRIPTION
This should fix the errors in your PR

The ast doesn't store the fact that the string is a raw string literal, so pasta can't output this; it just looks like a normal string without the extra formatting information that pasta attaches.

```
>>> import ast
>>> print ast.dump(ast.parse('r"foo"'))
Module(body=[Expr(value=Str(s='foo'))])
>>> import pasta
>>> print pasta.dump(pasta.parse('r"foo"'))
r"foo"
```

For `test_bytes`, it should output the `b` prefix in 3.x since it is a `Bytes` node, which is distinguishable form a `Str` node.